### PR TITLE
Use flexbox for homepage layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,9 @@
 <h1>The Interactive Fiction Archive</h1>
 </div>
 
+<div class="Columns">
+<div class="MainCol">
+
 <div class="Description">
 <blockquote class="QuoteBox">
 <p class="NoBottomMargin">
@@ -93,7 +96,7 @@ Please read the
 </p>
 
 </div>
-
+</div>
 
 <div class="RightCol">
 
@@ -130,6 +133,7 @@ Online discussion. Folks to answer your questions.
 <hr>
 </div>
 
+</div>
 </div>
 
 <div class="Footer">

--- a/misc/ifarchive.css
+++ b/misc/ifarchive.css
@@ -241,14 +241,22 @@ hr
 
 /* home page */
 
-#frontpage
-{
-	position: relative;
-}
-
 #frontpage .Header
 {
 	margin-bottom: 4em;
+}
+
+#frontpage .Columns
+{
+	display: flex;
+	gap: 0 6em;
+	justify-content: space-around;
+	flex-wrap: wrap;
+}
+
+#frontpage .MainCol
+{
+	max-width: 80ch;
 }
 
 #frontpage .Description blockquote
@@ -264,13 +272,11 @@ hr
 
 #frontpage .Description, #frontpage .ArchiveMirrors, #frontpage .Submissions, #frontpage .Introduction
 {
-	margin-right: 330px;
 	word-wrap: break-word;
 }
 
 #frontpage .RightCol
 {
-	position: absolute;
 	width: 270px;
 }
 
@@ -564,17 +570,6 @@ hr
 .Page 
 {
 	padding: 0.1em 3em 2em 3em;
-}
-
-#frontpage .Description, #frontpage .ArchiveMirrors, #frontpage .Submissions, #frontpage .Introduction
-{
-	margin-right: 60%;
-}
-
-#frontpage .RightCol
-{
-	position: absolute;
-	width: 40%;
 }
 
 }


### PR DESCRIPTION
The homepage gets buggy at certain layout widths.

<img width="492" alt="image" src="https://github.com/iftechfoundation/ifarchive-static/assets/96150/3affe82e-a5e4-4a20-a559-bbba037656c9">

I also find it unreadable when the page is very wide. (Common advice is to keep line lengths under `80ch`.)

<img width="1959" alt="image" src="https://github.com/iftechfoundation/ifarchive-static/assets/96150/cab58fc7-7e90-4e68-bc12-b7d704463c45">

In this implementation, the main column and the right column use flexbox, `flex-wrap: wrap` ensures that the image never overflows its box. `justify-content: space-around` ensures that the content is evenly spaced on large screen sizes.

<img width="1411" alt="image" src="https://github.com/iftechfoundation/ifarchive-static/assets/96150/cddd5c2d-bc6b-4240-a738-d16025b54838">
