### PR TITLE
Accept files under 1GB

### DIFF
--- a/md/org-procedures.md
+++ b/md/org-procedures.md
@@ -224,7 +224,7 @@ Speaking of enormous...
 
 As of early 2025, the archive contains some 37 gigabytes of files. (Up from 30 gigabytes in 2023!) A file that adds half a gigabyte to that total is a significant bump. The marginal cost of a gigabyte is small, but if we accept large files unthinkingly, we'd be on a path to having ten times as many gigabytes pretty soon.
 
-We should take a closer look at files that are over 100MB, and discuss them with the rest of the team. You can email the webuploaders list, or you can chat about it on Slack. Ask questions like these:
+We should take a closer look at files that are over 1GB, and discuss them with the rest of the team. You can email the webuploaders list, or you can chat about it on Slack. Ask questions like these:
 
 - Does it make sense to ask the uploader/author to make the file(s) smaller?
 - If the files contain large images or sounds, does the author have the rights to that material? (Always a question, but as a practical matter, we look at images and music harder.)


### PR DESCRIPTION
As we discussed on Slack, we'll be more welcoming to visual novels, which typically run in the range of hundreds of megabytes. Previously we said that we'd ask questions about files over 100MB, (i.e. most VNs).

This PR raises the "no questions asked" limit to 1GB, which should cover the vast majority of VNs.