### PR TITLE
Add table of contents to org docs

### DIFF
--- a/md/org-docs.md
+++ b/md/org-docs.md
@@ -1,5 +1,9 @@
 title: Using the Archive Admin Tool
 
+[TOC]
+
+-----
+
 The Admin Tool allows Archive volunteers to file Archive uploads and edit their descriptions. It's a fairly straightforward web interface.
 
 Note that there is no public login to the Admin Tool. Only Archive volunteers have accounts.

--- a/md/org-overview.md
+++ b/md/org-overview.md
@@ -1,6 +1,10 @@
 title: IF Archive organization and metadata
 changedate: February 18, 2024
 
+[TOC]
+
+-----
+
 We store files in directories. That's the job.
 
 The server is a tree of directories, which you can browse from the [top, here](https://ifarchive.org/indexes/if-archive/). The full directory list is [viewable here](https://ifarchive.org/indexes/dirlist.html). (This [`directory-tree`](https://ifarchive.org/if-archive/directory-tree) file is supposed to show a map of the whole thing, but it hasn't been updated since 2013 so it's probably a bit wrong.)

--- a/md/org-procedures.md
+++ b/md/org-procedures.md
@@ -1,6 +1,10 @@
 title: IF Archive volunteer procedures
 changedate: December 7, 2025
 
+[TOC]
+
+-----
+
 First, have a look at the [Archive uploading info][pubdocs]. This is the public post which explains the upload procedure to our users.
 
 [pubdocs]: uploader-docs.html

--- a/tools/build.py
+++ b/tools/build.py
@@ -27,7 +27,7 @@ jenv = Environment(
 jenv.globals['appcssuri'] = app_css_uri
 
 mdenv = markdown.Markdown(extensions=[
-    'attr_list', 'def_list', 'fenced_code', 'tables', 'meta',
+    'attr_list', 'def_list', 'fenced_code', 'tables', 'meta', 'toc'
 ])
 
 def build(filename):


### PR DESCRIPTION
Small addition to Markdown extensions to provide a table of contents to the documentation. This hopefully makes it easier for volunteers to navigate the docs.